### PR TITLE
Document tag_cards usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,18 @@ python -m src.tag_analysis \
 
 Use `--min-pair-count`, `--top-n`, and `--mechanic-rare-threshold` to tweak the
 report granularity for experimentation.
+
+## Generate tagged cards
+
+Produce a tagged oracle card export by running `tag_cards.py` against a
+Scryfall oracle dump:
+
+```
+python -m src.tag_cards \
+  --input data/oracle-cards-*.json \
+  --output data/tag_output/tagged-cards.json
+```
+
+The helper keeps only English cards by default. Use `--language any` to include
+every language, `--include-tokens` to keep token layouts, or `--limit` to sample
+the first _n_ results while iterating on heuristics.


### PR DESCRIPTION
## Summary
- add README guidance for running the tag_cards helper script to produce tagged card exports
- document optional flags for language filtering, token inclusion, and sampling while iterating on tag heuristics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb8b1a35f4832d8c1e34e50fa7feb1